### PR TITLE
コンポーネントをレンダー

### DIFF
--- a/tests/unit/mount.spec.js
+++ b/tests/unit/mount.spec.js
@@ -1,0 +1,31 @@
+import { mount, shallowMount } from "@vue/test-utils"
+import Vue from "vue"
+
+const Child = Vue.component("Child", {
+  name: "Child",
+  template: "<div>Child component</div>"
+})
+
+const Parent = Vue.component("Parent", {
+  name: "Parent",
+  template: "<div><child /></div>"
+})
+
+
+describe("Child", () => {
+  it("console child", () => {
+    const shallowWrapper = shallowMount(Child)
+    const mountWrapper = mount(Child)
+
+    console.log(shallowWrapper.html())
+    console.log(mountWrapper.html())
+  })
+
+  it("console parent", () => {
+    const shallowWrapper = shallowMount(Parent)
+    const mountWrapper = mount(Parent)
+
+    console.log(shallowWrapper.html())
+    console.log(mountWrapper.html())
+  })
+})


### PR DESCRIPTION
# mount / shallowMountのレンダー内容を比較

- mountは子コンポーネントも描画する。
- shallowMountでは子コンポーネントを描画せずに、スタブに置き換える。