### PR TITLE
プロップスのテスト

### DIFF
--- a/src/components/SubmitButton.vue
+++ b/src/components/SubmitButton.vue
@@ -1,0 +1,25 @@
+<template>
+  <div>
+    <span v-if="isAdmin">管理者権限を実行する</span>
+    <span v-else>権限がありません</span>
+    <button>
+      {{ msg }}
+    </button>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "SubmitButton",
+  props: {
+    msg: {
+      type: String,
+      required: true
+    },
+    isAdmin: {
+      type: Boolean,
+      default: false
+    }
+  }
+}
+</script>

--- a/tests/unit/SubmitButton.spec.js
+++ b/tests/unit/SubmitButton.spec.js
@@ -1,0 +1,18 @@
+import { shallowMount } from "@vue/test-utils"
+import SubmitButton from "@/components/SubmitButton.vue"
+
+describe("SubmitButton", () => {
+  it("権限がない状態のメッセージを表示する", () => {
+    const msg = "送信する"
+    const wrapper = shallowMount(SubmitButton, {
+      propsData: {
+        msg: msg
+      }
+    })
+
+    console.log(wrapper.html())
+
+    expect(wrapper.find("span").text()).toBe("権限がありません")
+    expect(wrapper.find("button").text()).toBe("送信する")
+  })
+})

--- a/tests/unit/SubmitButton.spec.js
+++ b/tests/unit/SubmitButton.spec.js
@@ -15,4 +15,18 @@ describe("SubmitButton", () => {
     expect(wrapper.find("span").text()).toBe("権限がありません")
     expect(wrapper.find("button").text()).toBe("送信する")
   })
+
+  it("権限がある状態のメッセージを表示する", () => {
+    const msg = "送信する"
+    const isAdmin = true
+    const wrapper = shallowMount(SubmitButton, {
+      propsData: {
+        msg,
+        isAdmin
+      }
+    })
+
+    expect(wrapper.find("span").text()).toBe("管理者権限を実行する")
+    expect(wrapper.find("button").text()).toBe("送信する")
+  })
 })

--- a/tests/unit/SubmitButton.spec.js
+++ b/tests/unit/SubmitButton.spec.js
@@ -2,29 +2,25 @@ import { shallowMount } from "@vue/test-utils"
 import SubmitButton from "@/components/SubmitButton.vue"
 
 describe("SubmitButton", () => {
-  it("権限がない状態のメッセージを表示する", () => {
-    const msg = "送信する"
-    const wrapper = shallowMount(SubmitButton, {
+  const msg = "送信する"
+  const factory = (propsData) => {
+    return shallowMount(SubmitButton, {
       propsData: {
-        msg: msg
+        msg,
+        ...propsData
       }
     })
+  }
 
-    console.log(wrapper.html())
+  it("権限がない状態のメッセージを表示する", () => {
+    const wrapper = factory()
 
     expect(wrapper.find("span").text()).toBe("権限がありません")
     expect(wrapper.find("button").text()).toBe("送信する")
   })
 
   it("権限がある状態のメッセージを表示する", () => {
-    const msg = "送信する"
-    const isAdmin = true
-    const wrapper = shallowMount(SubmitButton, {
-      propsData: {
-        msg,
-        isAdmin
-      }
-    })
+    const wrapper = factory({ isAdmin: true })
 
     expect(wrapper.find("span").text()).toBe("管理者権限を実行する")
     expect(wrapper.find("button").text()).toBe("送信する")


### PR DESCRIPTION
# mount / shallowMount で共通して使える `propsData` の扱い方。

第二引数のオブジェクトの中に書くことで、親コンポーネントから`props`として渡されたものとしてテストで使用できる。

```
const wrapper = shallowMount(Foo, {
  propsData: {
    foo: 'bar'
  }
})
```