### PR TITLE
算出プロパティ

### DIFF
--- a/src/components/NumberRenderer.vue
+++ b/src/components/NumberRenderer.vue
@@ -1,0 +1,15 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+export default {
+  name: "NumberRenderer",
+  props: {
+    even: {
+      type: Boolean,
+      required: true
+    }
+  }
+}
+</script>

--- a/src/components/NumberRenderer.vue
+++ b/src/components/NumberRenderer.vue
@@ -14,14 +14,17 @@ export default {
   computed: {
     numbers() {
       const evens = []
+      const odds = []
 
       for (let i = 1; i < 10; i++) {
         if (i % 2 === 0) {
           evens.push(i)
+        } else {
+          odds.push(i)
         }
       }
 
-      return evens.join(", ")
+      return this.even === true ? evens.join(", ") : odds.join(", ")
     }
   }
 }

--- a/src/components/NumberRenderer.vue
+++ b/src/components/NumberRenderer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div></div>
+  <div>{{ numbers }}</div>
 </template>
 
 <script>
@@ -9,6 +9,19 @@ export default {
     even: {
       type: Boolean,
       required: true
+    }
+  },
+  computed: {
+    numbers() {
+      const evens = []
+
+      for (let i = 1; i < 10; i++) {
+        if (i % 2 === 0) {
+          evens.push(i)
+        }
+      }
+
+      return evens.join(", ")
     }
   }
 }

--- a/tests/unit/NumberRenderer.spec.js
+++ b/tests/unit/NumberRenderer.spec.js
@@ -1,0 +1,14 @@
+import { shallowMount } from '@vue/test-utils'
+import NumberRenderer from "@/components/NumberRenderer.vue"
+
+describe("NumberRenderer", () => {
+  it("偶数をレンダー", () => {
+    const wrapper = shallowMount(NumberRenderer, {
+      propsData: {
+        even: true
+      }
+    })
+
+    expect(wrapper.text()).toBe("2, 4, 6, 8")
+  })
+})

--- a/tests/unit/NumberRenderer.spec.js
+++ b/tests/unit/NumberRenderer.spec.js
@@ -11,4 +11,10 @@ describe("NumberRenderer", () => {
 
     expect(wrapper.text()).toBe("2, 4, 6, 8")
   })
+
+  it("奇数をレンダー", () => {
+    const localThis = { even: false }
+
+    expect(NumberRenderer.computed.numbers.call(localThis)).toBe("1, 3, 5, 7, 9")
+  })
 })


### PR DESCRIPTION
# 算出プロパティのテストの書き方２つ

## 1. 算出プロパティの値をレンダーしてテストを書く
```
<template>
  <div>
    {{ numbers }}
  </div>
</template>
```
```
const wrapper = shallowMount(NumberRenderer, { propsData: { even: true } })
wrapper.text()
```

## 2. `call`を使ってテストを書く
コンポーネントをレンダーせずに算出プロパティをテストする
```
const localThis = { even: false }
NumberRenderer.computed.numbers.call(localThis)
```