### PR TITLE
発生したイベントのテスト

### DIFF
--- a/src/components/Emitter.vue
+++ b/src/components/Emitter.vue
@@ -1,0 +1,14 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+export default {
+  name: "Emitter",
+  methods: {
+    emitEvent() {
+      this.$emit("myEvent", "name", "password")
+    }
+  }
+}
+</script>

--- a/tests/unit/Emitter.spec.js
+++ b/tests/unit/Emitter.spec.js
@@ -1,0 +1,12 @@
+import { shallowMount } from "@vue/test-utils"
+import Emitter from "@/components/Emitter.vue"
+
+describe("Emitter", () => {
+  it("２つの引数があるイベントを発火する", () => {
+    const wrapper = shallowMount(Emitter)
+
+    wrapper.vm.emitEvent()
+
+    console.log(wrapper.emitted())
+  })
+})

--- a/tests/unit/Emitter.spec.js
+++ b/tests/unit/Emitter.spec.js
@@ -9,4 +9,13 @@ describe("Emitter", () => {
     
     expect(wrapper.emitted().myEvent[0]).toEqual(["name", "password"])
   })
+
+  it("コンポーネントをレンダーせずにイベントを検証する", () => {
+    const events = {}
+    const $emit = (event, ...args) => { events[event] = [...args] }
+
+    Emitter.methods.emitEvent.call({ $emit })
+
+    expect(events.myEvent).toEqual(["name", "password"])
+  })
 })

--- a/tests/unit/Emitter.spec.js
+++ b/tests/unit/Emitter.spec.js
@@ -6,7 +6,7 @@ describe("Emitter", () => {
     const wrapper = shallowMount(Emitter)
 
     wrapper.vm.emitEvent()
-
-    console.log(wrapper.emitted())
+    
+    expect(wrapper.emitted().myEvent[0]).toEqual(["name", "password"])
   })
 })


### PR DESCRIPTION
##  `emittedAPI`でコンポーネントによって発生したイベントを検証

呼び出したイベントはemittedが返すオブジェクトのプロパティになり、呼び出した回数分の配列となる
```
// Emitter.vue
this.$emit("myEvent", "name", "password")
```
```
// Emitter.spec.js
wrapper.vm.emitEvent()
wrapper.vm.emitEvent()
console.log(wrapper.emitted())
// => { myEvent: [ [ 'name', 'password' ], [ 'name', 'password' ] ] }
```

## $emitをモックしてcallで呼び出して、レンダーせずに検証できる
```
it("コンポーネントをレンダーせずにイベントを検証する", () => {
  const events = {}
  const $emit = (event, ...args) => { events[event] = [...args] }

  Emitter.methods.emitEvent.call({ $emit })

  expect(events.myEvent).toEqual(["name", "password"])
})
```