### PR TITLE
グローバルオブジェクトのモック

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
-  preset: "@vue/cli-plugin-unit-jest"
+  preset: "@vue/cli-plugin-unit-jest",
+  setupFiles: ["./jest.init.js"],
 };

--- a/jest.init.js
+++ b/jest.init.js
@@ -1,0 +1,6 @@
+import VueTestUtils from "@vue/test-utils"
+import translations from "./src/translations.js"
+
+const locale = "ja"
+
+VueTestUtils.config.mocks["$t"] = (msg) => translations[locale][msg]

--- a/package-lock.json
+++ b/package-lock.json
@@ -13039,6 +13039,11 @@
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==",
       "dev": true
     },
+    "vue-i18n": {
+      "version": "8.15.1",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-8.15.1.tgz",
+      "integrity": "sha512-GBbz8qYCu0U2LNu4IcuFLZiuyninG4k26knvhL7GZG5Ncp4RR2VKDEH6g8gQ6I+UUBCvH2MBQVPSdxWe4DBkPw=="
+    },
     "vue-jest": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/vue-jest/-/vue-jest-3.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "core-js": "^3.4.3",
     "vue": "^2.6.10",
+    "vue-i18n": "^8.15.1",
     "vue-router": "^3.1.3",
     "vuex": "^3.1.2"
   },

--- a/src/components/Bilingual.vue
+++ b/src/components/Bilingual.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="hello">
+    {{ $t("helloWorld") }}
+  </div>
+</template>
+
+<script>
+export default {
+  name: "Bilingual"
+}
+</script>

--- a/src/translations.js
+++ b/src/translations.js
@@ -1,0 +1,8 @@
+export default {
+  "en": {
+    helloWorld: "Hello world!"
+  },
+  "ja": {
+    helloWorld: "こんにちは、世界！"
+  }
+}

--- a/tests/unit/Bilingual.spec.js
+++ b/tests/unit/Bilingual.spec.js
@@ -3,10 +3,7 @@ import Bilingual from "@/components/Bilingual.vue"
 
 describe("Bilingual", () => {
   it("renders successfully", () => {
-    const wrapper = shallowMount(Bilingual, {
-      mocks: {
-        $t: (msg) => msg
-      }
-    })
+    const wrapper = shallowMount(Bilingual)
+    expect(wrapper.find(".hello").text()).toBe("こんにちは、世界！")
   })
 })

--- a/tests/unit/Bilingual.spec.js
+++ b/tests/unit/Bilingual.spec.js
@@ -1,0 +1,12 @@
+import { shallowMount } from "@vue/test-utils"
+import Bilingual from "@/components/Bilingual.vue"
+
+describe("Bilingual", () => {
+  it("renders successfully", () => {
+    const wrapper = shallowMount(Bilingual, {
+      mocks: {
+        $t: (msg) => msg
+      }
+    })
+  })
+})


### PR DESCRIPTION
# `vue-i18n`の`$t`をモックに差し替えてテスト

## 1. Mount時の`mocks`オプションによる差し替え
```javascript
const wrapper = shallowMount(Bilingual, {
  mocks: { $t: (msg) => msg }
}
```

## 2. configでデフォルトのモックを設定
### jest.init.js
```
module.exports = {
  ...,
  setupFiles: ["./jest.init.js"],
};
```

### jest.config.js
```
import VueTestUtils from "@vue/test-utils"
import translations from "./src/translations.js"

const locale = "en"

VueTestUtils.config.mocks["$t"] = (msg) => translations[locale][msg]
```