### PR TITLE
コンポーネントをスタブする

### DIFF
--- a/src/components/ComponentWithAsyncCall.vue
+++ b/src/components/ComponentWithAsyncCall.vue
@@ -1,0 +1,22 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+import axios from "axios"
+
+export default {
+  name: "ComponentWithAsyncCall",
+
+  created() {
+    this.makeApiCall()
+  },
+
+  methods: {
+    async makeApiCall() {
+      console.log("Making api call")
+      await axios.get("https://jsonplaceholder.typicode.com/posts/1")
+    }
+  },
+}
+</script>

--- a/src/components/ParentWithAPICallChild.vue
+++ b/src/components/ParentWithAPICallChild.vue
@@ -1,0 +1,14 @@
+<template>
+  <ComponentWithAsyncCall />
+</template>
+
+<script>
+import ComponentWithAsyncCall from "./ComponentWithAsyncCall.vue"
+
+export default {
+  name: "ParentWithAPICallChild",
+  components: {
+    ComponentWithAsyncCall
+  },
+}
+</script>

--- a/tests/unit/ParentWithAPICallChild.spec.js
+++ b/tests/unit/ParentWithAPICallChild.spec.js
@@ -1,0 +1,12 @@
+import { shallowMount, mount } from "@vue/test-utils"
+import ParentWithAPICallChild from "@/components/ParentWithAPICallChild.vue"
+import ComponentWithAsyncCall from "@/components/ComponentWithAsyncCall.vue"
+
+describe("ParentWithAPICallChild", () => {
+  it("renders with mount and does initialize API call", () => {
+    const wrapper = mount(ParentWithAPICallChild, {
+      stubs: { ComponentWithAsyncCall: true }
+    })
+    expect(wrapper.find(ComponentWithAsyncCall).exists()).toBe(true)
+  })
+})

--- a/tests/unit/ParentWithAPICallChild.spec.js
+++ b/tests/unit/ParentWithAPICallChild.spec.js
@@ -9,4 +9,9 @@ describe("ParentWithAPICallChild", () => {
     })
     expect(wrapper.find(ComponentWithAsyncCall).exists()).toBe(true)
   })
+
+  it("renders with shallowMount and does not initialize API call", () => {
+    const wrapper = shallowMount(ParentWithAPICallChild)
+    expect(wrapper.find(ComponentWithAsyncCall).exists()).toBe(true)
+  })
 })


### PR DESCRIPTION
# テスト時に、対象のコンポーネント以外のコンポーネントをスタブに差し替えてテストする

## 1. マウントオプション`stubs`を利用

```javascript
const wrapper = mount(ParentWithAPICallChild, {
  stubs: { ComponentWithAsyncCall: true }
})
```

もしくは具体的な要素も指定できる
```javascript
const wrapper = mount(ParentWithAPICallChild, {
  stubs: { ComponentWithAsyncCall: "<div class='stub'></div>" }
})
```

## 2. shallowMountを利用

自動で子コンポーネントをスタブに差し替えてくれる
```javascript
const wrapper = shallowMount(ParentWithAPICallChild)
```