### PR TITLE
Vuex in components - mutations and actions

### DIFF
--- a/src/components/ComponentWithButtons.vue
+++ b/src/components/ComponentWithButtons.vue
@@ -1,0 +1,41 @@
+<template>
+  <div>
+    <button 
+      class="commit" 
+      @click="handleCommit">
+      Commit
+    </button>
+
+    <button 
+      class="dispatch" 
+      @click="handleDispatch">
+      Dispatch
+    </button>
+
+    <button 
+      class="namespaced-dispatch" 
+      @click="handleNamespacedDispatch">
+      Namespaced Dispatch
+    </button>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "ComponentWithButtons",
+
+  methods: {
+    handleCommit() {
+      this.$store.commit("testMutation", { msg: "Test Commit" })
+    },
+
+    handleDispatch() {
+      this.$store.dispatch("testAction", { msg: "Test Dispatch" })
+    },
+
+    handleNamespacedDispatch() {
+      this.$store.dispatch("namespaced/very/deeply/testAction", { msg: "Test Namespaced Dispatch" })
+    }
+  }
+}
+</script>

--- a/tests/unit/ComponentWithButtons.spec.js
+++ b/tests/unit/ComponentWithButtons.spec.js
@@ -1,0 +1,26 @@
+import Vuex from "vuex"
+import { shallowMount, createLocalVue } from "@vue/test-utils"
+import ComponentWithButtons from "@/components/ComponentWithButtons.vue"
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
+
+const mutations = {
+  testMutation: jest.fn()
+}
+
+const store = new Vuex.Store({ mutations })
+
+describe("ComponentWithButtons", () => {
+  it("commits a mutation when a button is clicked", async () => {
+    const wrapper = shallowMount(ComponentWithButtons, { store, localVue })
+
+    wrapper.find(".commit").trigger("click")
+    await wrapper.vm.$nextTick()
+
+    expect(mutations.testMutation).toHaveBeenCalledWith(
+      {},
+      { msg: "Test Commit" }
+    )
+  })
+})

--- a/tests/unit/ComponentWithButtons.spec.js
+++ b/tests/unit/ComponentWithButtons.spec.js
@@ -37,4 +37,18 @@ describe("ComponentWithButtons", () => {
       "testAction", { msg: "Test Dispatch" }
     )
   })
+
+  it("dispatch a namespaced action when button is clicked", async () => {
+    const store = new Vuex.Store()
+    store.dispatch = jest.fn()
+    const wrapper = shallowMount(ComponentWithButtons, { store, localVue })
+
+    wrapper.find(".namespaced-dispatch").trigger("click")
+    await wrapper.vm.$nextTick()
+
+    expect(store.dispatch).toHaveBeenCalledWith(
+      "namespaced/very/deeply/testAction",
+      { msg: "Test Namespaced Dispatch" }
+    )
+  })
 })

--- a/tests/unit/ComponentWithButtons.spec.js
+++ b/tests/unit/ComponentWithButtons.spec.js
@@ -23,4 +23,18 @@ describe("ComponentWithButtons", () => {
       { msg: "Test Commit" }
     )
   })
+
+  it("dispatches an action when a button is clicked", async () => {
+    const mockStore = { dispatch: jest.fn() }
+    const wrapper = shallowMount(ComponentWithButtons, {
+      mocks: { $store: mockStore }
+    })
+
+    wrapper.find(".dispatch").trigger("click")
+    await wrapper.vm.$nextTick()
+
+    expect(mockStore.dispatch).toHaveBeenCalledWith(
+      "testAction", { msg: "Test Dispatch" }
+    )
+  })
 })


### PR DESCRIPTION
# コンポーネント内での mutations / actions のテスト

mutations / actions の挙動・機能自体は独立テストで担保する。
コンポーネント内で確認すべきは下記の２点。
- 正しい mutations / actions が呼び出されているか
- payloadは正しいか

## 1. テスト用のlocal Vueインスタンスを作ってテスト

```javascript
const localVue = createLocalVue()
localVue.use(Vuex)

const mutations = {
  testMutation: jest.fn()
}

const store = new Vuex.Store({ mutations })
```

mutationsは2つの引数で呼び出される。
1. 現在のstate
2. payload

```javascript
it("commits a mutation when a button is clicked", async () => {
  const wrapper = shallowMount(ComponentWithButtons, { store, localVue })

  wrapper.find(".commit").trigger("click")
  await wrapper.vm.$nextTick()

  expect(mutations.testMutation).toHaveBeenCalledWith(
    {},
    { msg: "Test Commit" }
  )
})
```


## 2. mocksオプションでstoreを差し替えてテスト

actionsは2つの引数で呼び出される。
1. action名
2. payload

```javascript
const mockStore = { dispatch: jest.fn() }
const wrapper = shallowMount(ComponentWithButtons, {
  mocks: { $store: mockStore }
})

wrapper.find(".dispatch").trigger("click")
await wrapper.vm.$nextTick()

expect(mockStore.dispatch).toHaveBeenCalledWith(
  "testAction", { msg: "Test Dispatch" }
)
```

## 3. テスト用storeとMockのdispatchメソッドを使ってテスト

```javascript
const store = new Vuex.Store()
store.dispatch = jest.fn()
const wrapper = shallowMount(ComponentWithButtons, { store, localVue })

wrapper.find(".namespaced-dispatch").trigger("click")
await wrapper.vm.$nextTick()

expect(store.dispatch).toHaveBeenCalledWith(
  "namespaced/very/deeply/testAction",
  { msg: "Test Namespaced Dispatch" }
)
```