### PR TITLE
Composition API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1863,6 +1863,14 @@
         }
       }
     },
+    "@vue/composition-api": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/composition-api/-/composition-api-0.3.4.tgz",
+      "integrity": "sha512-aMbg/pEk0PSQAIFyWWLqbAmaCCTx1kFq+49KZslIBJH9Wqos7eEPLtMv4gGxd/EcciBIgfbtUXaXGg/O3mheRA==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
     "@vue/eslint-config-prettier": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@vue/eslint-config-prettier/-/eslint-config-prettier-5.1.0.tgz",
@@ -12636,8 +12644,7 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "dev": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "@vue/composition-api": "^0.3.4",
     "core-js": "^3.4.3",
     "vue": "^2.6.10",
     "vue-i18n": "^8.15.1",

--- a/src/components/CompositionApi.vue
+++ b/src/components/CompositionApi.vue
@@ -1,0 +1,47 @@
+<template>
+  <div>
+    <div class="message">{{ uppercasedMessage }}</div>
+    <div class="count">
+      Count: {{ state.count }}
+    </div>
+    <button @click="increment">Increment</button>
+  </div>
+</template>
+
+<script>
+import Vue from 'vue'
+import VueCompositionApi from '@vue/composition-api'
+
+Vue.use(VueCompositionApi)
+
+import { 
+  reactive,
+  computed
+} from '@vue/composition-api'
+
+export default {
+  name: 'CompositionApi',
+
+  props: {
+    message: {
+      type: String
+    }
+  },
+
+  setup(props) {
+    const state = reactive({
+      count: 0
+    })
+
+    const increment = () => {
+      state.count += 1
+    }
+
+    return {
+      state,
+      increment,
+      uppercasedMessage: computed(() => props.message.toUpperCase())
+    }
+  }
+}
+</script>

--- a/tests/unit/CompositionApi.spec.js
+++ b/tests/unit/CompositionApi.spec.js
@@ -12,4 +12,15 @@ describe("CompositionApi", () => {
 
     expect(wrapper.find(".message").text()).toBe("TESTING THE COMPOSITION API")
   })
+
+  it("increments a count when button is clicked", async () => {
+    const wrapper = shallowMount(CompositionApi, {
+      propsData: { message: '' }
+    })
+
+    wrapper.find("button").trigger("click")
+    wrapper.vm.$nextTick()
+
+    expect(wrapper.find(".count").text()).toBe("Count: 1")
+  })
 })

--- a/tests/unit/CompositionApi.spec.js
+++ b/tests/unit/CompositionApi.spec.js
@@ -1,0 +1,15 @@
+import { shallowMount } from "@vue/test-utils"
+
+import CompositionApi from "@/components/CompositionApi.vue"
+
+describe("CompositionApi", () => {
+  it("renders a message", () => {
+    const wrapper = shallowMount(CompositionApi, {
+      propsData: {
+        message: "Testing the composition API"
+      }
+    })
+
+    expect(wrapper.find(".message").text()).toBe("TESTING THE COMPOSITION API")
+  })
+})


### PR DESCRIPTION
# Vue3から追加の`Composition API`でのテスト

基本的に、従来の`Options API`の時とテスト内容は変わらない。
内部の詳細な実装に注目するのではなく、コンポーネントの状態にのみ注視すれば良い。

## Propsの表示確認
```javascript
import { shallowMount } from "@vue/test-utils"
import CompositionApi from "@/components/CompositionApi.vue"

describe("CompositionApi", () => {
  it("renders a message", () => {
    const wrapper = shallowMount(CompositionApi, {
      propsData: {
        message: "Testing the composition API"
      }
    })

    expect(wrapper.find(".message").text()).toBe("TESTING THE COMPOSITION API")
  })
})
```

## ボタンクリックの挙動確認
```javascript
import { shallowMount } from "@vue/test-utils"
import CompositionApi from "@/components/CompositionApi.vue"

describe("CompositionApi", () => {
  it("increments a count when button is clicked", async () => {
    const wrapper = shallowMount(CompositionApi, {
      propsData: { message: '' }
    })

    wrapper.find('button').trigger('click')
    await wrapper.vm.$nextTick()

    expect(wrapper.find(".count").text()).toBe("Count: 1")
  })
})
```