### PR TITLE
プロップスのテスト(2)

### DIFF
--- a/tests/unit/SubmitButton.spec.js
+++ b/tests/unit/SubmitButton.spec.js
@@ -2,7 +2,13 @@ import { shallowMount } from "@vue/test-utils";
 import SubmitButton from "@/components/SubmitButton.vue";
 
 describe("SubmitButton", () => {
-  it("権限がない状態のメッセージを表示する", () => {});
+  it("権限がない状態のメッセージを表示する", () => {
+    const msg = "送信する";
+    const wrapper = shallowMount(SubmitButton, { propsData: { msg } });
+
+    expect(wrapper.find("span").text()).toBe("権限がありません");
+    expect(wrapper.find("button").text()).toBe("送信する");
+  });
 
   it("権限がある状態のメッセージを表示する", () => {});
 });

--- a/tests/unit/SubmitButton.spec.js
+++ b/tests/unit/SubmitButton.spec.js
@@ -1,19 +1,21 @@
 import { shallowMount } from "@vue/test-utils";
 import SubmitButton from "@/components/SubmitButton.vue";
 
+const msg = "送信する";
+const factory = propsData => {
+  return shallowMount(SubmitButton, { propsData: { msg, ...propsData } });
+};
+
 describe("SubmitButton", () => {
   it("権限がない状態のメッセージを表示する", () => {
-    const msg = "送信する";
-    const wrapper = shallowMount(SubmitButton, { propsData: { msg } });
+    const wrapper = factory();
 
     expect(wrapper.find("span").text()).toBe("権限がありません");
     expect(wrapper.find("button").text()).toBe("送信する");
   });
 
   it("権限がある状態のメッセージを表示する", () => {
-    const msg = "送信する";
-    const isAdmin = true;
-    const wrapper = shallowMount(SubmitButton, { propsData: { msg, isAdmin } });
+    const wrapper = factory({ isAdmin: true });
 
     expect(wrapper.find("span").text()).toBe("管理者権限を実行する");
     expect(wrapper.find("button").text()).toBe("送信する");

--- a/tests/unit/SubmitButton.spec.js
+++ b/tests/unit/SubmitButton.spec.js
@@ -10,5 +10,12 @@ describe("SubmitButton", () => {
     expect(wrapper.find("button").text()).toBe("送信する");
   });
 
-  it("権限がある状態のメッセージを表示する", () => {});
+  it("権限がある状態のメッセージを表示する", () => {
+    const msg = "送信する";
+    const isAdmin = true;
+    const wrapper = shallowMount(SubmitButton, { propsData: { msg, isAdmin } });
+
+    expect(wrapper.find("span").text()).toBe("管理者権限を実行する");
+    expect(wrapper.find("button").text()).toBe("送信する");
+  });
 });


### PR DESCRIPTION
親コンポーネントから渡される`props`をテスト時に再現するには、
`mount / shallowMount`メソッドの第2引数のオブジェクトに、propsDataとして指定。

```javascript
const wrapper = shallowMount(ComponentHoge, {
  propsData: {
    foo: 'bar'
  }
})
```