### PR TITLE
ユーザー入力をシミュレーション(2)

### DIFF
--- a/tests/unit/FormSubmitter.spec.js
+++ b/tests/unit/FormSubmitter.spec.js
@@ -3,7 +3,16 @@ import { shallowMount } from "@vue/test-utils";
 import FormSubmitter from "@/components/FormSubmitter.vue";
 
 describe.skip("FormSubmitter", () => {
-  it("フォームを更新するとお知らせを表示", () => {});
+  it("フォームを更新するとお知らせを表示", () => {
+    const wrapper = shallowMount(FormSubmitter);
+
+    wrapper.find("[data-username]").setValue("alice");
+    wrapper.find("form").trigger("submit.prevent");
+
+    expect(wrapper.find(".message").text()).toBe(
+      "aliceさん、お問い合わせ、ありがとうございます。"
+    );
+  });
 });
 
 describe("FormSubmitter", () => {

--- a/tests/unit/FormSubmitter.spec.js
+++ b/tests/unit/FormSubmitter.spec.js
@@ -2,6 +2,19 @@ import flushPromises from "flush-promises";
 import { shallowMount } from "@vue/test-utils";
 import FormSubmitter from "@/components/FormSubmitter.vue";
 
+let url = "";
+let data = "";
+
+const mockHttp = {
+  get: (_url, _data) => {
+    return new Promise((resolve, _reject) => {
+      url = _url;
+      data = _data;
+      resolve();
+    });
+  }
+};
+
 describe.skip("FormSubmitter", () => {
   it("フォームを更新するとお知らせを表示", () => {
     const wrapper = shallowMount(FormSubmitter);
@@ -16,5 +29,22 @@ describe.skip("FormSubmitter", () => {
 });
 
 describe("FormSubmitter", () => {
-  it("フォームを更新するとお知らせを表示", () => {});
+  it("フォームを更新するとお知らせを表示", async () => {
+    const wrapper = shallowMount(FormSubmitter, {
+      mocks: {
+        $http: mockHttp
+      }
+    });
+
+    wrapper.find("[data-username]").setValue("alice");
+    wrapper.find("form").trigger("submit.prevent");
+
+    await flushPromises();
+
+    expect(wrapper.find(".message").text()).toBe(
+      "aliceさん、お問い合わせ、ありがとうございます。"
+    );
+    expect(url).toBe("/api/v1/register");
+    expect(data).toEqual({ username: "alice" });
+  });
 });


### PR DESCRIPTION
`setValue`でインプット要素に値を設定
```javascript
wrapper.find("[data-username]").setValue("alice")
```

---

`flush-promises`を使ってPromiseをすぐにresolveさせる
```javascript
import { shallowMount } from '@vue/test-utils'
import flushPromises from 'flush-promises'
import Foo from './Foo'
jest.mock('axios')

it('fetches async when a button is clicked', async () => {
  const wrapper = shallowMount(Foo)
  wrapper.find('button').trigger('click')
  await flushPromises()
  expect(wrapper.vm.value).toBe('value')
})
```
[参考: 非同期動作のテスト](https://vue-test-utils.vuejs.org/ja/guides/testing-async-components.html)