### PR TITLE
発生したイベントのテスト(2)

### DIFF
--- a/tests/unit/Emitter.spec.js
+++ b/tests/unit/Emitter.spec.js
@@ -2,7 +2,13 @@ import { shallowMount } from "@vue/test-utils";
 import Emitter from "@/components/Emitter.vue";
 
 describe("Emitter", () => {
-  it("２つの引数があるイベントを発火する", () => {});
+  it("２つの引数があるイベントを発火する", () => {
+    const wrapper = shallowMount(Emitter);
+
+    wrapper.vm.emitEvent();
+
+    expect(wrapper.emitted().myEvent[0]).toEqual(["name", "password"]);
+  });
 
   it("コンポーネントをレンダーせずにイベントを検証する", () => {});
 });

--- a/tests/unit/Emitter.spec.js
+++ b/tests/unit/Emitter.spec.js
@@ -10,5 +10,14 @@ describe("Emitter", () => {
     expect(wrapper.emitted().myEvent[0]).toEqual(["name", "password"]);
   });
 
-  it("コンポーネントをレンダーせずにイベントを検証する", () => {});
+  it("コンポーネントをレンダーせずにイベントを検証する", () => {
+    const events = {};
+    const $emit = (event, ...args) => {
+      events[event] = [...args];
+    };
+
+    Emitter.methods.emitEvent.call({ $emit });
+
+    expect(events.myEvent).toEqual(["name", "password"]);
+  });
 });


### PR DESCRIPTION
vue-test-utilsの`emitted`API
```javascript
const wrapper = shallowMount(Emitter)

wrapper.vm.emitEvent()
console.log(wrapper.emitted())
// => { myEvent: [ [ 'name', 'password' ] ] }

wrapper.vm.emitEvent()
console.log(wrapper.emitted())
// => { myEvent: [ [ 'name', 'password' ], [ 'name', 'password' ] ] }
```
---

コンポーネントをマウントせずにイベントのテスト
```javascript
const events = {};
const $emit = (event, ...args) => {
  events[event] = [...args];
};

Emitter.methods.emitEvent.call({ $emit });

expect(events.myEvent).toEqual(["name", "password"]);
```
