### PR TITLE
グローバルオブジェクトのモック(2)

### DIFF
--- a/tests/unit/Bilingual.spec.js
+++ b/tests/unit/Bilingual.spec.js
@@ -2,5 +2,9 @@ import { shallowMount } from "@vue/test-utils";
 import Bilingual from "@/components/Bilingual.vue";
 
 describe("Bilingual", () => {
-  it("renders successfully", () => {});
+  it("renders successfully", () => {
+    const wrapper = shallowMount(Bilingual);
+
+    expect(wrapper.text()).toBe("こんにちは、世界！");
+  });
 });


### PR DESCRIPTION
`Vue.prototype`にアタッチされたプロパティのモック方法

|ライブラリ|グローバルオブジェクト|
|:--|:--|
|Vuex|$store|
|Vue Router|$router|
|vue-i18n|$t|

---

1. mocks mounting option
個別のテストのみ差し替え
```javascript
const wrapper = shallowMount(Bilingual, {
    mocks: { $t: (msg) => msg }
}
```

---

2. vue-test-utilsの`config`API
全テストに共通で影響
```javascript
// jest.config.js

module.exports = {
  ...
  setupFiles: ["./jest.init.js"],
};
```

```javascript
// jest.init.js

const locale = "ja"
VueTestUtils.config.mocks["$t"] = (msg) => translations[locale][msg]
```