### PR TITLE
コンポーネントをスタブする(2)

### DIFF
--- a/tests/unit/ParentWithAPICallChild.spec.js
+++ b/tests/unit/ParentWithAPICallChild.spec.js
@@ -10,5 +10,8 @@ describe("ParentWithAPICallChild", () => {
     expect(wrapper.find(ComponentWithAsyncCall).exists()).toBe(true);
   });
 
-  it("renders with shallowMount and does not initialize API call", () => {});
+  it("renders with shallowMount and does not initialize API call", () => {
+    const wrapper = shallowMount(ParentWithAPICallChild);
+    expect(wrapper.find(ComponentWithAsyncCall).exists()).toBe(true);
+  });
 });

--- a/tests/unit/ParentWithAPICallChild.spec.js
+++ b/tests/unit/ParentWithAPICallChild.spec.js
@@ -3,7 +3,12 @@ import ParentWithAPICallChild from "@/components/ParentWithAPICallChild.vue";
 import ComponentWithAsyncCall from "@/components/ComponentWithAsyncCall.vue";
 
 describe("ParentWithAPICallChild", () => {
-  it("renders with mount and does initialize API call", () => {});
+  it("renders with mount and does initialize API call", () => {
+    const wrapper = mount(ParentWithAPICallChild, {
+      stubs: { ComponentWithAsyncCall: true }
+    });
+    expect(wrapper.find(ComponentWithAsyncCall).exists()).toBe(true);
+  });
 
   it("renders with shallowMount and does not initialize API call", () => {});
 });


### PR DESCRIPTION
コンポーネントをテストする時は、対象外の子コンポーネントはスタブに差し替えてテストする方が望ましい。

1. `stubs`を使う
```javascript
const wrapper = mount(ParentWithAPICallChild, {
    stubs: { ComponentWithAsyncCall: true }
});
```
もしくは
```javascript
const wrapper = mount(ParentWithAPICallChild, {
    stubs: { ComponentWithAsyncCall: "<div class='stub'></div>" }
});
```
---

2. `shallowMount`を使う
```javascript
const wrapper = shallowMount(ParentWithAPICallChild);
```