### PR TITLE
要素とコンポーネントを検索する(2)

### DIFF
--- a/tests/unit/Parent.spec.js
+++ b/tests/unit/Parent.spec.js
@@ -3,7 +3,11 @@ import Parent from "@/components/Parent.vue";
 import Child from "@/components/Child.vue";
 
 describe("Parent", () => {
-  it("does not render a span", () => {});
+  it("does not render a span", () => {
+    const wrapper = shallowMount(Parent);
+
+    expect(wrapper.find("span").isVisible()).toBe(false);
+  });
 
   it("does render a span", () => {});
 

--- a/tests/unit/Parent.spec.js
+++ b/tests/unit/Parent.spec.js
@@ -18,7 +18,11 @@ describe("Parent", () => {
     expect(wrapper.find("span").isVisible()).toBe(true);
   });
 
-  it("does not render a Child component", () => {});
+  it("does not render a Child component", () => {
+    const wrapper = shallowMount(Parent);
+
+    expect(wrapper.find(Child).exists()).toBe(false);
+  });
 
   it("renders a Child component", () => {});
 });

--- a/tests/unit/Parent.spec.js
+++ b/tests/unit/Parent.spec.js
@@ -9,7 +9,14 @@ describe("Parent", () => {
     expect(wrapper.find("span").isVisible()).toBe(false);
   });
 
-  it("does render a span", () => {});
+  it("does render a span", () => {
+    const wrapper = shallowMount(Parent, {
+      data() {
+        return { showSpan: true };
+      }
+    });
+    expect(wrapper.find("span").isVisible()).toBe(true);
+  });
 
   it("does not render a Child component", () => {});
 

--- a/tests/unit/Parent.spec.js
+++ b/tests/unit/Parent.spec.js
@@ -24,5 +24,12 @@ describe("Parent", () => {
     expect(wrapper.find(Child).exists()).toBe(false);
   });
 
-  it("renders a Child component", () => {});
+  it("renders a Child component", () => {
+    const wrapper = shallowMount(Parent, {
+      data() {
+        return { showChild: true };
+      }
+    });
+    expect(wrapper.find(Child).exists()).toBe(true);
+  });
 });

--- a/tests/unit/ParentWithManyChildren.spec.js
+++ b/tests/unit/ParentWithManyChildren.spec.js
@@ -3,5 +3,9 @@ import ParentWithManyChildren from "@/components/ParentWithManyChildren.vue";
 import Child from "@/components/Child.vue";
 
 describe("ParentWithManyChildren", () => {
-  it("renders many children", () => {});
+  it("renders many children", () => {
+    const wrapper = shallowMount(ParentWithManyChildren);
+
+    expect(wrapper.findAll(Child).length).toBe(3);
+  });
 });


### PR DESCRIPTION
`data`の値を変えてテスト
```javascript
const wrapper = shallowMount(Parent, {
  data() {
    return { showSpan: true };
  }
});
```

---

`find`による検査対象の指定
1. HTML要素の場合
querySelectorのシンタックスで、findに指定
```javascript
wrapper.find("span")
```

2. 子コンポーネントの場合
下記２パターンの様にコンポーネント名をfindに指定
```javascript
wrapper.find(Child)
// もしくは
wrapper.find({ name: "Child" })
```

---

表示確認、存在確認

|条件付きレンダリング|概要|確認メソッド|
|:---|:---|:---|
|v-if|条件がtrueの時になって初めて描画|exists|
|v-show|要素は常に描画され、CSSベースの切り替え|isVisible|